### PR TITLE
Expense update budget

### DIFF
--- a/strukly-backend/docker-compose-dev/docker-compose.yml
+++ b/strukly-backend/docker-compose-dev/docker-compose.yml
@@ -1,7 +1,6 @@
 # Use postgres/example user/password credentials
 
 services:
-
   db:
     image: postgres:alpine
     restart: always
@@ -13,10 +12,11 @@ services:
     #    target: /dev/shm
     #    tmpfs:
     #      size: 134217728 # 128*2^20 bytes = 128Mb
-    ports: 
+    ports:
       - 5432:5432
     environment:
-      POSTGRES_PASSWORD: example
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_USER: postgres
 
   adminer:
     image: adminer

--- a/strukly-backend/src/application/use_cases/expense/create_expense.ts
+++ b/strukly-backend/src/application/use_cases/expense/create_expense.ts
@@ -2,14 +2,27 @@ import { CreateExpenseRequest } from "src/infrastructure/schemas";
 import { mapCreateExpenseRequestToExpense } from "src/infrastructure/mappers";
 import ExpenseService from "../../../domain/services/expense_service";
 
+import BudgetService from "src/domain/services/budget_service";
+import UserID from "src/domain/values/user_id";
+
 export default class CreateExpenseUseCase {
-  constructor(private readonly expenseService: ExpenseService) {}
+  constructor(
+    private readonly expenseService: ExpenseService,
+    private readonly budgetService: BudgetService,
+  ) {}
   async execute(
     userID: string,
     expense: CreateExpenseRequest,
   ) {
     const newExpense = mapCreateExpenseRequestToExpense(userID, expense);
 
-    return this.expenseService.createExpense(newExpense);
+    const createdExpense = await this.expenseService.createExpense(newExpense);
+
+    await this.budgetService.useBudget(
+      new UserID(userID),
+      createdExpense.header.totalAmount.value,
+    );
+
+    return createdExpense;
   }
 }

--- a/strukly-backend/src/application/use_cases/expense/delete_expense.ts
+++ b/strukly-backend/src/application/use_cases/expense/delete_expense.ts
@@ -3,6 +3,8 @@ import ExpenseID from "src/domain/values/expense_id";
 import UserID from "src/domain/values/user_id";
 
 import BudgetService from "src/domain/services/budget_service";
+import NotFoundError from "src/domain/errors/NotFoundError";
+import InvalidDataError from "src/domain/errors/InvalidDataError";
 
 export default class DeleteExpenseUseCase {
   constructor(
@@ -18,7 +20,7 @@ export default class DeleteExpenseUseCase {
     );
 
     if (!expense) {
-        throw new Error("Expense not found");
+        throw new NotFoundError("Expense not found");
     }
 
     // Check if expense is in the current budget period
@@ -31,7 +33,7 @@ export default class DeleteExpenseUseCase {
       expenseMonth !== currentBudget.month ||
       expenseYear !== currentBudget.year
     ) {
-        throw new Error("Cannot delete expense from a previous budget period");
+        throw new InvalidDataError("Cannot delete expense from a previous budget period");
     }
 
     const totalAmount = expense.header.totalAmount.value;

--- a/strukly-backend/src/application/use_cases/expense/delete_expense.ts
+++ b/strukly-backend/src/application/use_cases/expense/delete_expense.ts
@@ -10,8 +10,8 @@ export default class DeleteExpenseUseCase {
     private readonly budgetService: BudgetService,
   ) {}
 
-  async execute(userId: string, expenseId: string): Promise<void> {
-    const user = new UserID(userId);
+  async execute(userID: string, expenseId: string): Promise<void> {
+    const user = new UserID(userID);
     const expense = await this.expenseService.getExpenseByID(
         user, 
         new ExpenseID(expenseId)

--- a/strukly-backend/src/application/use_cases/expense/update_expense.ts
+++ b/strukly-backend/src/application/use_cases/expense/update_expense.ts
@@ -7,6 +7,8 @@ import Money from "src/domain/values/money";
 import ExpenseItem from "src/domain/entities/expense_item";
 
 import BudgetService from "src/domain/services/budget_service";
+import NotFoundError from "src/domain/errors/NotFoundError";
+import InvalidDataError from "src/domain/errors/InvalidDataError";
 
 export default class UpdateExpenseUseCase {
   constructor(
@@ -25,7 +27,7 @@ export default class UpdateExpenseUseCase {
     );
 
     if (!expense) {
-      throw new Error("Expense not found");
+      throw new NotFoundError("Expense not found");
     }
 
     // Check if expense is in the current budget period
@@ -45,7 +47,7 @@ export default class UpdateExpenseUseCase {
       expenseMonth !== currentBudget.month ||
       expenseYear !== currentBudget.year
     ) {
-        throw new Error("Cannot update expense from a previous budget period");
+        throw new InvalidDataError("Cannot update expense from a previous budget period");
     }
 
     const oldTotal = expense.header.totalAmount.value;

--- a/strukly-backend/src/application/use_cases/expense/update_expense.ts
+++ b/strukly-backend/src/application/use_cases/expense/update_expense.ts
@@ -6,21 +6,49 @@ import ExpenseCategory from "src/domain/values/expense_category";
 import Money from "src/domain/values/money";
 import ExpenseItem from "src/domain/entities/expense_item";
 
+import BudgetService from "src/domain/services/budget_service";
+
 export default class UpdateExpenseUseCase {
-  constructor(private readonly expenseService: ExpenseService) {}
+  constructor(
+    private readonly expenseService: ExpenseService,
+    private readonly budgetService: BudgetService,
+  ) {}
   async execute(
     userID: string,
     expenseID: string,
     updateValues: UpdateExpenseRequest,
   ) {
+    const user = new UserID(userID);
     const expense = await this.expenseService.getExpenseByID(
-      new UserID(userID),
+      user,
       new ExpenseID(expenseID),
     );
 
     if (!expense) {
       throw new Error("Expense not found");
     }
+
+    // Check if expense is in the current budget period
+    const currentBudget = await this.budgetService.getCurrentUserBudget(user);
+    const expenseDate = expense.header.dateTime;
+    
+    // We compare month and year. 
+    // Javascript getMonth() is 0-indexed, budget.month is 1-indexed (usually, based on getUTCMonth() + 1 in service)
+    // Let's verify how month is stored. Prisma model says Int.
+    // BudgetService: monthNow = now.getUTCMonth() + 1;
+    // So we should compare expenseDate.getUTCMonth() + 1 and expenseDate.getUTCFullYear()
+    
+    const expenseMonth = expenseDate.getUTCMonth() + 1;
+    const expenseYear = expenseDate.getUTCFullYear();
+
+    if (
+      expenseMonth !== currentBudget.month ||
+      expenseYear !== currentBudget.year
+    ) {
+        throw new Error("Cannot update expense from a previous budget period");
+    }
+
+    const oldTotal = expense.header.totalAmount.value;
 
     expense.updateHeader({
       dateTime: new Date(updateValues.dateTime),
@@ -58,6 +86,15 @@ export default class UpdateExpenseUseCase {
       ),
     );
 
-    return this.expenseService.updateExpense(new UserID(userID), expense);
+    const updatedExpense = await this.expenseService.updateExpense(new UserID(userID), expense);
+    
+    const newTotal = updatedExpense.header.totalAmount.value;
+    const delta = newTotal - oldTotal;
+
+    if (delta !== 0) {
+        await this.budgetService.useBudget(user, delta);
+    }
+
+    return updatedExpense;
   }
 }

--- a/strukly-backend/src/composition_root.ts
+++ b/strukly-backend/src/composition_root.ts
@@ -84,7 +84,8 @@ export const deleteGoalItemUseCase = new DeleteGoalItemUseCase(goalItemRepositor
 
 // expense
 export const createExpenseUseCase = new CreateExpenseUseCase(
-  expenseService
+  expenseService,
+  budgetService
 );
 export const getExpenseListUseCase = new GetMonthlyExpenseListUseCase(
   expenseService
@@ -96,10 +97,12 @@ export const getExpenseDetailUseCase = new GetExpenseDetailUseCase(
   expenseService
 );
 export const updateExpenseUseCase = new UpdateExpenseUseCase(
-  expenseService
+  expenseService,
+  budgetService
 );
 export const deleteExpenseUseCase = new DeleteExpenseUseCase(
-  expenseService
+  expenseService,
+  budgetService
 );
 export const imageToExpenseUseCase = new ScanExpenseImageUseCase(
   languageModelService

--- a/strukly-backend/src/tests/expense_budget_flow.test.ts
+++ b/strukly-backend/src/tests/expense_budget_flow.test.ts
@@ -1,0 +1,179 @@
+
+import CreateExpenseUseCase from "../application/use_cases/expense/create_expense";
+import UpdateExpenseUseCase from "../application/use_cases/expense/update_expense";
+import DeleteExpenseUseCase from "../application/use_cases/expense/delete_expense";
+import ExpenseService from "../domain/services/expense_service";
+import BudgetService from "../domain/services/budget_service";
+import UserID from "../domain/values/user_id";
+import ExpenseID from "../domain/values/expense_id";
+import Money from "../domain/values/money";
+import { CreateExpenseRequest, UpdateExpenseRequest } from "../infrastructure/schemas";
+import ExpenseCategory from "../domain/values/expense_category";
+import ExpenseHeader from "../domain/entities/expense_header";
+import Expense from "../domain/aggregates/expense";
+import BudgetHistory from "../domain/entities/budget_history";
+
+// Mock Services
+jest.mock("../domain/services/expense_service");
+jest.mock("../domain/services/budget_service");
+
+describe("Expense Budget Flow", () => {
+  let createExpenseUseCase: CreateExpenseUseCase;
+  let updateExpenseUseCase: UpdateExpenseUseCase;
+  let deleteExpenseUseCase: DeleteExpenseUseCase;
+  let mockExpenseService: jest.Mocked<ExpenseService>;
+  let mockBudgetService: jest.Mocked<BudgetService>;
+
+  const userID = "user-123";
+  const expenseID = "expense-123";
+  
+  // Date setup
+  const now = new Date();
+  const currentMonth = now.getUTCMonth() + 1;
+  const currentYear = now.getUTCFullYear();
+  
+  // Create a previous month date
+  const prevMonthDate = new Date(now);
+  prevMonthDate.setMonth(prevMonthDate.getMonth() - 1);
+
+
+  beforeEach(() => {
+    mockExpenseService = new ExpenseService({} as any) as any;
+    mockBudgetService = new BudgetService({} as any, {} as any) as any;
+
+    createExpenseUseCase = new CreateExpenseUseCase(mockExpenseService, mockBudgetService);
+    updateExpenseUseCase = new UpdateExpenseUseCase(mockExpenseService, mockBudgetService);
+    deleteExpenseUseCase = new DeleteExpenseUseCase(mockExpenseService, mockBudgetService);
+  });
+
+  const validExpenseRequest: CreateExpenseRequest = {
+    vendorName: "Test Vendor",
+    category: "food",
+    dateTime: now.toISOString(),
+    items: [],
+    subtotalAmount: { amount: 100, currency: "IDR" },
+    taxAmount: { amount: 0, currency: "IDR" },
+    discountAmount: { amount: 0, currency: "IDR" },
+    serviceAmount: { amount: 0, currency: "IDR" },
+  };
+
+    const createMockExpense = (amount: number, date: Date) => {
+        const header = new ExpenseHeader({
+            id: new ExpenseID(expenseID),
+            userID: new UserID(userID),
+            vendorName: "Test",
+            category: ExpenseCategory.fromString("food"),
+            dateTime: date,
+            subtotalAmount: new Money(amount, "IDR"),
+            taxAmount: new Money(0, "IDR"),
+            discountAmount: new Money(0, "IDR"),
+            serviceAmount: new Money(0, "IDR"),
+            totalAmount: new Money(amount, "IDR"),
+        });
+        return new Expense(header, []);
+    };
+    
+    const mockBudgetHistory = {
+        month: currentMonth,
+        year: currentYear
+    } as BudgetHistory;
+
+  describe("Create Expense", () => {
+    it("should create expense and use budget", async () => {
+      const mockResultExpense = createMockExpense(100, now);
+      mockExpenseService.createExpense.mockResolvedValue(mockResultExpense);
+
+      await createExpenseUseCase.execute(userID, validExpenseRequest);
+
+      expect(mockExpenseService.createExpense).toHaveBeenCalled();
+      expect(mockBudgetService.useBudget).toHaveBeenCalledWith(
+        expect.any(UserID),
+        100
+      );
+    });
+  });
+
+  describe("Update Expense", () => {
+      it("should update expense and adjust budget with delta (increase)", async () => {
+          const oldExpense = createMockExpense(100, now);
+          const updatedExpense = createMockExpense(150, now); // Increased by 50
+
+          mockExpenseService.getExpenseByID.mockResolvedValue(oldExpense);
+          mockBudgetService.getCurrentUserBudget.mockResolvedValue(mockBudgetHistory);
+          mockExpenseService.updateExpense.mockResolvedValue(updatedExpense);
+          
+          const updateRequest: UpdateExpenseRequest = {
+              ...validExpenseRequest,
+              subtotalAmount: { amount: 150, currency: "IDR" }
+          };
+
+          await updateExpenseUseCase.execute(userID, expenseID, updateRequest);
+          
+          expect(mockBudgetService.useBudget).toHaveBeenCalledWith(
+              expect.any(UserID),
+              50 // Delta 150 - 100
+          );
+      });
+
+      it("should update expense and adjust budget with delta (decrease)", async () => {
+          const oldExpense = createMockExpense(100, now);
+          const updatedExpense = createMockExpense(80, now); // Decreased by 20
+
+          mockExpenseService.getExpenseByID.mockResolvedValue(oldExpense);
+          mockBudgetService.getCurrentUserBudget.mockResolvedValue(mockBudgetHistory);
+          mockExpenseService.updateExpense.mockResolvedValue(updatedExpense);
+
+          const updateRequest: UpdateExpenseRequest = {
+              ...validExpenseRequest,
+              subtotalAmount: { amount: 80, currency: "IDR" }
+          };
+
+          await updateExpenseUseCase.execute(userID, expenseID, updateRequest);
+
+          expect(mockBudgetService.useBudget).toHaveBeenCalledWith(
+              expect.any(UserID),
+              -20 // Delta 80 - 100
+          );
+      });
+      
+      it("should throw error if updating expense from previous month", async () => {
+          const oldExpense = createMockExpense(100, prevMonthDate);
+          mockExpenseService.getExpenseByID.mockResolvedValue(oldExpense);
+          mockBudgetService.getCurrentUserBudget.mockResolvedValue(mockBudgetHistory);
+
+          await expect(updateExpenseUseCase.execute(userID, expenseID, validExpenseRequest as any))
+            .rejects
+            .toThrow("Cannot update expense from a previous budget period");
+            
+          expect(mockExpenseService.updateExpense).not.toHaveBeenCalled();
+      });
+  });
+
+  describe("Delete Expense", () => {
+      it("should delete expense and refund budget", async () => {
+          const expense = createMockExpense(100, now);
+          mockExpenseService.getExpenseByID.mockResolvedValue(expense);
+          mockBudgetService.getCurrentUserBudget.mockResolvedValue(mockBudgetHistory);
+
+          await deleteExpenseUseCase.execute(userID, expenseID);
+
+          expect(mockExpenseService.deleteExpenseByID).toHaveBeenCalled();
+          expect(mockBudgetService.useBudget).toHaveBeenCalledWith(
+              expect.any(UserID),
+              -100 // Refund
+          );
+      });
+      
+      it("should throw error if deleting expense from previous month", async () => {
+          const expense = createMockExpense(100, prevMonthDate);
+          mockExpenseService.getExpenseByID.mockResolvedValue(expense);
+          mockBudgetService.getCurrentUserBudget.mockResolvedValue(mockBudgetHistory);
+
+          await expect(deleteExpenseUseCase.execute(userID, expenseID))
+            .rejects
+            .toThrow("Cannot delete expense from a previous budget period");
+
+          expect(mockExpenseService.deleteExpenseByID).not.toHaveBeenCalled();
+      });
+  });
+});


### PR DESCRIPTION
This pull request introduces budget tracking and enforcement into the expense management flow. Now, expense creation, updates, and deletions will directly affect the user's budget, and expenses from previous budget periods cannot be modified or removed. The composition root is updated to inject the new `BudgetService` dependency, and a comprehensive test suite is added to verify the expense-budget interactions.

**Expense-Budget Integration**

* Added budget usage and adjustment logic to `CreateExpenseUseCase`, `UpdateExpenseUseCase`, and `DeleteExpenseUseCase`. Expense creation deducts from budget, updates adjust by the difference, and deletions refund the budget. [[1]](diffhunk://#diff-d72335ec419d926f67a4415c15ad318cfabf5bd488507f26e784cb9f02741b7fR5-R26) [[2]](diffhunk://#diff-c1f7be0b78a2dbf143957ca36fad696f8fd0eea56317eee9cbb0883be424f532R9-R52) [[3]](diffhunk://#diff-c1f7be0b78a2dbf143957ca36fad696f8fd0eea56317eee9cbb0883be424f532L61-R98) [[4]](diffhunk://#diff-0024c6fa23a3727b886730e9270f241f5e69cb66a3def80fccd2a4a9ae5b0f6bR5-R45)
* Enforced that expenses can only be updated or deleted if they belong to the current budget period; otherwise, an error is thrown. [[1]](diffhunk://#diff-c1f7be0b78a2dbf143957ca36fad696f8fd0eea56317eee9cbb0883be424f532R9-R52) [[2]](diffhunk://#diff-0024c6fa23a3727b886730e9270f241f5e69cb66a3def80fccd2a4a9ae5b0f6bR5-R45)

**Dependency Injection Updates**

* Updated the composition root in `src/composition_root.ts` to inject `BudgetService` into all expense use cases. [[1]](diffhunk://#diff-6ba5f0ab92a1adae82e372cf706f8c0288d9972e823cfdc7cd381beb3cfb2c5bL87-R88) [[2]](diffhunk://#diff-6ba5f0ab92a1adae82e372cf706f8c0288d9972e823cfdc7cd381beb3cfb2c5bL99-R105)

**Testing**

* Added a new test suite `expense_budget_flow.test.ts` to verify that expenses correctly interact with the budget, including creation, updates (with budget delta), deletions (with refunds), and enforcement of current budget period restrictions.

**Configuration**

* Changed the default Postgres user and password in `docker-compose.yml` to `postgres` for local development consistency.

---

If you have any questions about how budget integration works or how the test suite covers these scenarios, let me know!