### PR TITLE
fix: add settings back button and hide nav

### DIFF
--- a/strukly-frontend/src/App.tsx
+++ b/strukly-frontend/src/App.tsx
@@ -30,6 +30,7 @@ const App = () => {
     "/expense/add",
     "/expense/camera",
     "/expense/:id",
+    "/settings",
   ];
   const isProtectedPath = !hideNavbarRoutes.includes(location.pathname);
 

--- a/strukly-frontend/src/pages/Settings.tsx
+++ b/strukly-frontend/src/pages/Settings.tsx
@@ -1,11 +1,23 @@
+import { useNavigate } from "react-router-dom";
+
 import useUserAuth from "../store/UserAuthStore";
 import Button from "../components/button/Button";
+import BackIcon from "../components/utilityIcons/BackIcon";
 
 export default function Settings() {
   const logout = useUserAuth((s) => s.logout);
+  const navigate = useNavigate();
+
   return (
-    <div>
-      <div className="m-8 flex items-center justify-center">
+    <div className="pb-16 min-h-screen bg-background">
+      <div className="bg-surface px-4 py-5 flex items-center gap-3 sticky top-0 z-10 shadow-sm border-b-2 border-border">
+        <button onClick={() => navigate(-1)}>
+          <BackIcon width={28} height={28} />
+        </button>
+        <h1 className="text-xl font-semibold">Settings</h1>
+      </div>
+
+      <div className="p-6 flex items-center justify-center">
         <Button onClick={logout}>Log out</Button>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- hide the mobile nav bar on the settings screen
- add a sticky header with a back button and keep logout centered on the settings page

## Rationale
- addresses mahasigma-sunib/strukly#112 request to close settings cleanly and reduce nav clutter

## Changes
- strukly-frontend/src/App.tsx: exclude /settings from routes that render the mobile nav
- strukly-frontend/src/pages/Settings.tsx: add back icon header and layout tweaks

## Test Plan
- not run (UI-only change)

Fixes #112